### PR TITLE
refactor: unsubscribe tokens in KiteTickerSubscriber

### DIFF
--- a/src/ticker.rs
+++ b/src/ticker.rs
@@ -194,7 +194,13 @@ impl KiteTickerSubscriber {
     instrument_tokens: &[u32],
   ) -> Result<(), String> {
     let tokens = self.get_subscribed_or(instrument_tokens);
-    self.ticker.unsubscribe_cmd(tokens.as_slice()).await
+    match self.ticker.unsubscribe_cmd(tokens.as_slice()).await{
+      Ok(_) => {
+        self.subscribed_tokens.retain(|k, _| !tokens.contains(k));
+        Ok(())
+      },
+      Err(e) => Err(e)
+    }
   }
 
   /// Get the next message from the server, waiting if necessary.


### PR DESCRIPTION
This commit refactors the `unsubscribe_tokens` method in the `KiteTickerSubscriber` struct. Instead of directly unsubscribing the tokens and updating the `subscribed_tokens` field, it now uses a match statement to handle the result of the `unsubscribe_cmd` method. If the unsubscribe is successful, the tokens are removed from the `subscribed_tokens` using the `retain` method. If there is an error, it is returned.

The code changes in this commit ensure that the `subscribed_tokens` field is updated correctly when unsubscribing tokens.

Co-authored-by: Kaushik Chakraborty <git@kaushikc.org>

Note: Commit message is generated by AI. Please use with caution.